### PR TITLE
Added support for encoding/decoding unicode fraction glyphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can create an instance of `Fraction` using one of its constructors.
    final frac2 = Fraction.fromString("-2/4"); // -2/4
    final frac3 = Fraction.fromString("2/-4"); // Error
    final frac4 = Fraction.fromString("-2"); // -2/1
+   final frac5 = Fraction.fromString("¼"); // 1/4
    ```
 
  - **double**: represents a double as a fraction. Note that irrational numbers cannot be converted into
@@ -57,6 +58,12 @@ Note that a `Fraction` object is **immutable** so methods that require changing 
 ```dart
 final fraction = Fraction.fromString("12/20"); // 12/20
 final reduced = fraction.reduce(); // now it's simplified to  3/5
+```
+
+Fraction strings can be encoded to unicode fraction glyphs when possible.
+
+```dart
+final fractionGlyph = encodeFractionGlyphs('1/2'); // ½
 ```
 
 Two fractions are equal if their "cross product" is equal. For example `1/2` and `3/6` are said to be equivalent because `1*6 = 3*2` (and in fact `3/6` is the same as `1/2`). Be sure to check out the official documentation at [pub.dev](https://pub.dev/documentation/fraction/latest/fraction/Fraction-class.html) for a complete overview of the API.

--- a/lib/fraction.dart
+++ b/lib/fraction.dart
@@ -7,3 +7,4 @@ export 'src/extensions/mixed_num.dart';
 export 'src/extensions/mixed_string.dart';
 export 'src/mixed.dart';
 export 'src/utils/exceptions.dart';
+export 'src/utils/fraction_glyphs.dart';

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -1,4 +1,5 @@
 import 'package:fraction/fraction.dart';
+import 'package:fraction/src/utils/fraction_glyphs.dart';
 
 /// Dart representation of a fraction having both the numerator and the denominator
 /// as integers.
@@ -77,13 +78,17 @@ class Fraction implements Comparable<Fraction> {
   /// Fraction.fromString("5/-2") // throws FractionException
   /// ```
   Fraction.fromString(String value) {
-    // Checking the format of the string
-    if ((!_fractionRegex.hasMatch(value)) || (value.contains('/-'))) {
+    // Convert any unicode fraction glyphs (e.g. '½' to '1/2')
+    final decodedValue = decodeFractionGlyphs(value);
+
+    // Check the format of the string
+    final matchesRegex = _fractionRegex.hasMatch(decodedValue);
+    if (!matchesRegex || decodedValue.contains('/-')) {
       throw FractionException('The string $value is not a valid fraction');
     }
 
     // Remove the leading + if present
-    final fraction = value.replaceAll('+', '');
+    final fraction = decodedValue.replaceAll('+', '');
 
     // Look for the / separator
     final barPos = fraction.indexOf('/');

--- a/lib/src/mixed.dart
+++ b/lib/src/mixed.dart
@@ -81,8 +81,11 @@ class MixedFraction implements Comparable<MixedFraction> {
     const errorObj = MixedFractionException("The string must be in the form 'a "
         "b/c' with exactly one space between the whole part and the fraction");
 
+    // Convert any unicode fraction glyphs (e.g. '½' to '1/2')
+    final decodedValue = decodeFractionGlyphs(value);
+
     // Check for the space
-    if (!value.contains(' ')) {
+    if (!decodedValue.contains(' ')) {
       throw errorObj;
     }
 
@@ -91,7 +94,7 @@ class MixedFraction implements Comparable<MixedFraction> {
      *  - parts[0]: the whole part (an integer)
      *  - parts[1]: the fraction (a string)
      * */
-    final parts = value.split(' ');
+    final parts = decodedValue.split(' ');
 
     if (parts.length != 2) {
       throw errorObj;

--- a/lib/src/utils/fraction_glyphs.dart
+++ b/lib/src/utils/fraction_glyphs.dart
@@ -1,0 +1,84 @@
+/// Replaces any fractions of the form n/m  in the given string with unicode
+/// vulgar fraction glyphs.
+///
+/// For example, '1/2' would be converted to '½'.
+String encodeFractionGlyphs(String value) {
+  final fractionValues = _valuesToGlyphs.keys.join('|');
+
+  return value.replaceAllMapped(
+    RegExp('([0-9]?)($fractionValues)(?![0-9])'),
+    (match) {
+      final hasPrecedingNumber = match[1]!.isNotEmpty;
+
+      if (hasPrecedingNumber) {
+        return match[0]!; // Original string
+      } else {
+        final matchedFractionValue = match[2]!;
+        return _valuesToGlyphs[matchedFractionValue]!;
+      }
+    },
+  );
+}
+
+/// Replaces any unicode vulgar fraction glyphs in the given string with
+/// fractions of the form n/m.
+///
+/// For example, '½' would be converted to '1/2'.
+///
+/// If a number character immediately precedes a fraction glyph (e.g. '2¼") then
+/// resulting value will be separated with a space ('2 1/4' rather than '21/4').
+String decodeFractionGlyphs(String value) {
+  final String glyphCharacters = _glyphsToValues.keys.join('|');
+
+  return value.replaceAllMapped(
+    RegExp('([0-9]?)($glyphCharacters)'),
+    (match) {
+      final replacement = _glyphsToValues[match[2]]!;
+      return match[1]!.isEmpty ? replacement : '${match[1]} $replacement';
+    },
+  );
+}
+
+/// Maps vulgar fraction glyphs to fraction values for the form n/m.
+const _glyphsToValues = {
+  '½': '1/2',
+  '⅓': '1/3',
+  '⅔': '2/3',
+  '¼': '1/4',
+  '¾': '3/4',
+  '⅕': '1/5',
+  '⅖': '2/5',
+  '⅗': '3/5',
+  '⅘': '4/5',
+  '⅙': '1/6',
+  '⅚': '5/6',
+  '⅐': '1/7',
+  '⅛': '1/8',
+  '⅜': '3/8',
+  '⅝': '5/8',
+  '⅞': '7/8',
+  '⅑': '1/9',
+  '⅒': '1/10',
+};
+
+/// Maps fraction values of the form n/m to vulgar fraction glyphs.
+const _valuesToGlyphs = {
+  '1/2': '½',
+  '1/3': '⅓',
+  '2/3': '⅔',
+  '1/4': '¼',
+  '3/4': '¾',
+  '1/5': '⅕',
+  '2/5': '⅖',
+  '3/5': '⅗',
+  '4/5': '⅘',
+  '1/6': '⅙',
+  '5/6': '⅚',
+  '1/7': '⅐',
+  '1/8': '⅛',
+  '3/8': '⅜',
+  '5/8': '⅝',
+  '7/8': '⅞',
+  '1/9': '⅑',
+  '1/10': '⅒',
+};

--- a/test/extensions/mixed_string_test.dart
+++ b/test/extensions/mixed_string_test.dart
@@ -32,6 +32,7 @@ void main() {
         'Making sure that the boolean check is safe to be used before converting',
         () {
       expect('1 3/5'.isMixedFraction(), isTrue);
+      expect('3 ¾'.isMixedFraction(), isTrue);
       expect('0 -3/5'.isMixedFraction(), isTrue);
       expect(''.isMixedFraction(), isFalse);
       expect('7/4'.isMixedFraction(), isFalse);

--- a/test/fraction_test.dart
+++ b/test/fraction_test.dart
@@ -56,6 +56,7 @@ void main() {
       expect(Fraction.fromString('3/5'), equals(Fraction(3, 5)));
       expect(Fraction.fromString('-3/5'), equals(Fraction(-3, 5)));
       expect(Fraction.fromString('7'), equals(Fraction(7)));
+      expect(Fraction.fromString('½'), equals(Fraction(1, 2)));
       expect(Fraction.fromString('-6'), equals(Fraction(-6)));
 
       // Invalid conversions

--- a/test/mixed_test.dart
+++ b/test/mixed_test.dart
@@ -106,6 +106,9 @@ void main() {
       expect(MixedFraction.fromString('1 5/3'),
           equals(MixedFraction(whole: 2, numerator: 2, denominator: 3)));
 
+      expect(MixedFraction.fromString('3⅕'),
+          equals(MixedFraction(whole: 3, numerator: 1, denominator: 5)));
+
       // Invalid conversions
       expect(() => MixedFraction.fromString('1/2'),
           throwsA(isA<MixedFractionException>()));

--- a/test/utils/fraction_glyphs_test.dart
+++ b/test/utils/fraction_glyphs_test.dart
@@ -1,0 +1,38 @@
+import 'package:fraction/src/utils/fraction_glyphs.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Encoding glyphs', () {
+    test(
+      'Replaces fractions in strings with no other text',
+      () => expect(encodeFractionGlyphs('1/2'), '½'),
+    );
+
+    test(
+      'Replaces fractions in strings with other text',
+      () => expect(encodeFractionGlyphs('some 1/4 text'), 'some ¼ text'),
+    );
+
+    test(
+      'Does not replace fractions with preceding numbers',
+      () => expect(encodeFractionGlyphs('21/2'), '21/2'),
+    );
+  });
+
+  group('Decoding glyphs', () {
+    test(
+      'Replaces fraction glyphs in strings with no other text',
+      () => expect(decodeFractionGlyphs('½'), '1/2'),
+    );
+
+    test(
+      'Replaces fraction glyphs in strings with other text',
+      () => expect(decodeFractionGlyphs('some ¼ text'), 'some 1/4 text'),
+    );
+
+    test(
+      'Correctly replaces fraction glyphs in mixed fractions',
+      () => expect(decodeFractionGlyphs('2½'), '2 1/2'),
+    );
+  });
+}


### PR DESCRIPTION
These changes add support for unicode fraction glyphs like '½', '⅔', etc through the top-level functions `encodeFractionGlyphs`and `decodeFractionGlyphs`. `Fraction.fromString` and `MixedFraction.fromString` now support strings with unicode fraction glyphs by calling `decodeFractionGlyphs` as a first step.

I'm not sure if you want to keep this package more 'math-oriented' and keep string parsing out of it, so feel free to reject if you don't think the changes belong here. It's just something I needed for my use case and figured I'd share. :)