### PR TITLE
chore: Added stricter linter rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.0]
+ - Added stricter linter rules with `lints` and `dart_code_metrics` packages
+ - Dependencies updates
+
 ## [3.0.2]
  - Dependencies updates
  - Fixed formatting to increase pub score

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,462 +1,218 @@
+include: package:lints/recommended.yaml
+
 analyzer:
-  errors:
-    todo: info
-    include_file_not_found: ignore
-  exclude:
-    - example/**
+  plugins:
+    - dart_code_metrics
+
+dart_code_metrics:
+  anti-patterns:
+    - long-parameter-list
+  metrics:
+    cyclomatic-complexity: 20
+    number-of-parameters: 6
+    maximum-nesting: 5
+  metrics-exclude:
+    - test/**
+  rules:
+    - avoid-unused-parameters
+    - avoid-wrapping-in-padding
+    - binary-expression-operand-order
+    - double-literal-format
+    - newline-before-return
+    - no-boolean-literal-compare
+    - no-equal-then-else
+    - no-object-declaration
+    - prefer-trailing-comma
 
 linter:
   rules:
     # Prevents accidental return type changes which results in a breaking API
     # change. Enforcing return type makes API changes visible in a diff.
-    - always_declare_return_types
+    always_declare_return_types: true
 
     # Don't put the statement part of an if, for, while, do on the same line as
     # the expression, even if it is short. Doing so makes it unclear that there
     # is relevant code there. This is especially important for early returns.
-    - always_put_control_body_on_new_line
-
-    # All non nullable named parameters should be and annotated with @required.
-    - always_require_non_null_named_parameters
-
-    # Protect against unintentionally overriding superclass members
-    - annotate_overrides
+    always_put_control_body_on_new_line: true
 
     # Highlights boolean expressions which can be simplified
-    - avoid_bool_literals_in_conditional_expressions
+    avoid_bool_literals_in_conditional_expressions: true
 
     # Errors aren't for catching but to prevent prior to runtime
-    - avoid_catching_errors
+    avoid_catching_errors: true
 
     # Can usually be replaced with an extension
-    - avoid_classes_with_only_static_members
+    avoid_classes_with_only_static_members: true
 
     # Only useful when targeting JS. Kept in case it comes into play with
     # Flutter Web.
-    - avoid_double_and_int_checks
-
-    # Prevents accidental empty else cases.
-    - avoid_empty_else
+    avoid_double_and_int_checks: true
 
     # Use different quotes instead of escaping
-    - avoid_escaping_inner_quotes
+    avoid_escaping_inner_quotes: true
 
     # Prevents unnecessary allocation of a field
-    - avoid_field_initializers_in_const_classes
-
-    # Prevents allocating a lambda and allows return/break/continue control
-    # flow statements inside the loop
-    - avoid_function_literals_in_foreach_calls
-
-    # Don't break value types by implementing them
-    - avoid_implementing_value_types
-
-    # Removes redundant `= null;`
-    - avoid_init_to_null
-
-    # Null checks aren't required in ==() operators
-    - avoid_null_checks_in_equality_operators
+    avoid_field_initializers_in_const_classes: true
 
     # Good APIs don't use ambiguous boolean parameters. Instead use named
     # parameters
-    - avoid_positional_boolean_parameters
-
-    # Don't call print in production code
-    - avoid_print
+    avoid_positional_boolean_parameters: true
 
     # Always prefer function references over typedefs.
     # Jumping twice in code to see the signature of a lambda sucks.
     # This is different from the flutter analysis_options
-    - avoid_private_typedef_functions
+    avoid_private_typedef_functions: true
 
     # Don't explicitly set defaults
-    - avoid_redundant_argument_values
-
-    # package or relative? Let's end the discussion and use package everywhere
-    - avoid_relative_lib_imports
-
-    # Setters always return void, therefore defining void is redundant
-    - avoid_return_types_on_setters
+    avoid_redundant_argument_values: true
 
     # Don't use `Future?`, therefore never return null instead of a Future.
-    - avoid_returning_null_for_future
-
-    # Use empty returns, don't show off with you knowledge about dart internals
-    - avoid_returning_null_for_void
+    avoid_returning_null_for_future: true
 
     # Prevents logical inconsistencies. It's good practice to define getters for
     # all existing setters.
-    - avoid_setters_without_getters
-
-    # Don't reuse a type parameter when on with the same name already exists in
-    # the same scope
-    - avoid_shadowing_type_parameters
-
-    # A single cascade operator can be replaced with a normal method call
-    - avoid_single_cascade_in_expression_statements
-
-    # Don't use a parameter names which can be confused with a types
-    - avoid_types_as_parameter_names
-
-    # Containers without parameters have no effect and can be removed
-    - avoid_unnecessary_containers
+    avoid_setters_without_getters: true
 
     # Unused parameters should be removed
-    - avoid_unused_constructor_parameters
+    avoid_unused_constructor_parameters: true
 
     # For async functions use `Future<void>` as return value, not `void`
     # This allows usage of the await keyword and prevents operations from
     # running in parallel.
-    - avoid_void_async
-
-    # Flutter mobile only: Web packages aren't available in mobile flutter apps
-    # https://dart-lang.github.io/linter/lints/avoid_web_libraries_in_flutter.html
-    - avoid_web_libraries_in_flutter
-
-    # Use the await keyword only for futures. There is nothing to await in
-    # synchronous code
-    - await_only_futures
-
-    # Follow the style guide and use UpperCamelCase for extensions
-    - camel_case_extensions
-
-    # Follow the style guide and use UpperCamelCase for class names and typedefs
-    - camel_case_types
+    avoid_void_async: true
 
     # Prevents leaks and code executing after their lifecycle.
-    - cancel_subscriptions
-
-    # Follow standard dart naming style.
-    - constant_identifier_names
-
-    # Prevents hard to debug code
-    - control_flow_in_finally
-
-    # Single line `if`s are fine, but when a new line splits the bool expression
-    # and body curly braces are recommended. It prevents the danging else
-    # problem and easily allows the addition of more lines inside the if body
-    - curly_braces_in_flow_control_structures
+    cancel_subscriptions: true
 
     # Follows dart style. Fully supported by IDEs and no manual effort for a
     # consistent style
-    - directives_ordering
+    directives_ordering: true
 
     # String.fromEnvironment looks up env variables at compile time. The
     # variable is baked in by the compiler and can't be changed by environment
     # variables.
-    - do_not_use_environment
-
-    # Add a comment why no further error handling is required
-    - empty_catches
-
-    # Removed empty constructor bodies
-    - empty_constructor_bodies
-
-    # Don't allow empty if bodies. Works together with
-    # curly_braces_in_flow_control_structures
-    - empty_statements
-
-    # Enums aren't powerful enough, now enum like classes get the same linting
-    # support
-    - exhaustive_cases
-
-    # Follow dart file naming schema
-    - file_names
-
-    # hashCode and equals need to be consistent. One can't live without another.
-    - hash_and_equals
-
-    # DON'T import implementation files from another package.
-    - implementation_imports
+    do_not_use_environment: true
 
     # Although there are some false positives, this lint generally catches
     # unnecessary checks.
-    - invariant_booleans
-
-    # Type check for Iterable<T>.contains(other) where other is! T
-    # otherwise contains will always report false. Those errors are usually very
-    # hard to catch.
-    - iterable_contains_unrelated_type
+    invariant_booleans: true
 
     # Hint to join return and assignment
-    - join_return_with_assignment
-
-    # Makes sure a library name is a valid dart identifier
-    - library_names
-
-    # Follow dart style
-    - library_prefixes
-
-    # Type check for List<T>.remove(item) where item is! T. The list can't
-    # contain item. Those errors are not directly obvious especially when
-    # refactoring.
-    - list_remove_unrelated_type
+    join_return_with_assignment: true
 
     # Good for libraries to prevent unnecessary code paths.
     # False positives may occur for applications when boolean properties are
     # generated by external programs producing auto-generated source code
     #
     # Known issue: while(true) loops https://github.com/dart-lang/linter/issues/453
-    - literal_only_boolean_expressions
+    literal_only_boolean_expressions: true
 
     # Don't forget the whitespaces at the end
-    - missing_whitespace_between_adjacent_strings
+    missing_whitespace_between_adjacent_strings: true
 
     # Concat Strings obviously with `+` inside a list.
-    - no_adjacent_strings_in_list
-
-    # Second case is basically dead code which will never be reached.
-    - no_duplicate_case_values
-
-    # Flutter only: `createState` shouldn't pass information into the state
-    - no_logic_in_create_state
+    no_adjacent_strings_in_list: true
 
     # calling `runtimeType` may be a performance problem
-    - no_runtimeType_toString
-
-    # Follow dart style naming conventions
-    - non_constant_identifier_names
-
-    # Might become irrelevant when non-nullable types land in dart. Until then
-    # use this lint check which checks for non null arguments for specific dart
-    # sdk methods.
-    - null_closures
+    no_runtimeType_toString: true
 
     # Defining interfaces (abstract classes), with only one method, makes sense
     # architecture wise.
     # Discussion: https://github.com/passsy/dart-lint/issues/2
-    - one_member_abstracts
-
-    # Highlights unintentionally overridden fields.
-    - overridden_fields
+    one_member_abstracts: true
 
     # Only relevant for packages, not applications or general dart code
-    - package_api_docs
-
-    # Follow dart style package naming convention
-    - package_names
-
-    # Seems very rare, especially for applications.
-    - package_prefixed_library_names
+    package_api_docs: true
 
     # Most likely a mistake, if not: bad practice
-    - parameter_assignments
+    parameter_assignments: true
 
     # Makes it easier to migrate to const constructors and to have final fields
-    - prefer_asserts_in_initializer_lists
+    prefer_asserts_in_initializer_lists: true
 
     # Assertions blocks don't require a message because they throw simple to
     # understand errors
-    - prefer_asserts_with_message
-
-    # Collection literals are shorter. They exists, use them.
-    - prefer_collection_literals
-
-    # Use the ??= operator when possible
-    - prefer_conditional_assignment
-
-    # Always use const when possible, make runtime faster
-    - prefer_const_constructors
-
-    # Add a const constructor when possible
-    - prefer_const_constructors_in_immutables
-
-    # final is good, const is better
-    - prefer_const_declarations
-
-    # Always use const when possible, make runtime faster
-    - prefer_const_literals_to_create_immutables
+    prefer_asserts_with_message: true
 
     # Dart has named constructors. Static methods in other languages (java) are
     # a workaround which don't have named constructors.
-    - prefer_constructors_over_static_methods
-
-    # Contains may be faster and is easier to read
-    - prefer_contains
-
-    # Prevent confusion with call-side when using named parameters
-    - prefer_equal_for_default_values
-
-    # Avoid accidental reassignments and allows the compiler to do optimizations
-    - prefer_final_fields
+    prefer_constructors_over_static_methods: true
 
     # Helps avoid accidental reassignments and allows the compiler to do
     # optimizations.
-    - prefer_final_in_for_each
+    prefer_final_in_for_each: true
 
     # Helps avoid accidental reassignments and allows the compiler to do
     # optimizations.
-    - prefer_final_locals
+    prefer_final_locals: true
 
     # Dense code isn't necessarily better code. But it's nice.
-    - prefer_foreach
-
-    # Saves lot of code
-    - prefer_for_elements_to_map_fromIterable
-
-    # As Dart allows local function declarations, it is a good practice to use
-    # them in the place of function literals.
-    - prefer_function_declarations_over_variables
-
-    # For consistency
-    - prefer_generic_function_type_aliases
+    prefer_foreach: true
 
     # Allows potential usage of const
-    - prefer_if_elements_to_conditional_expressions
-
-    # Dart has a special operator for this, use it
-    - prefer_if_null_operators
-
-    # Terser code
-    - prefer_initializing_formals
-
-    # Easier move towards const, and way easier to read
-    - prefer_inlined_adds
+    prefer_if_elements_to_conditional_expressions: true
 
     # Interpolate, use less "", '' and +
-    - prefer_interpolation_to_compose_strings
-
-    # Iterables do not necessary know their length
-    - prefer_is_empty
-
-    # Easier to read
-    - prefer_is_not_empty
-
-    # Use the `foo is! Foo` instead of `!(foo is Foo)`
-    - prefer_is_not_operator
-
-    # Easier to read
-    - prefer_iterable_whereType
-
-    # Makes expressions with null checks easier to read
-    - prefer_null_aware_operators
+    prefer_interpolation_to_compose_strings: true
 
     # Use whatever makes you happy. noexcuse doesn't define a style
-    - prefer_single_quotes
-
-    # Allows potential usage of const
-    - prefer_spread_collections
-
-    # Define types
-    - prefer_typing_uninitialized_variables
-
-    # Null is not a type, use void
-    - prefer_void_to_null
-
-    # Document the replacement API
-    - provide_deprecation_message
+    prefer_single_quotes: true
 
     # Definitely not a rule for standard dart code. Maybe relevant for packages
     # It's relevant here.
-    - public_member_api_docs
+    public_member_api_docs: true
 
     # Hints accidental recursions
-    - recursive_getters
-
-    # Flutter only, prefer SizedBox over Container which offers a
-    # const constructors
-    - sized_box_for_whitespace
-
-    # Follow dart style use triple slashes
-    - slash_for_doc_comments
+    recursive_getters: true
 
     # Flutter only, always put child last
-    - sort_child_properties_last
+    sort_child_properties_last: true
 
     # Any sorting is better than no sorting
-    - sort_pub_dependencies
+    sort_pub_dependencies: true
 
     # Default constructor comes first
-    - sort_unnamed_constructors_first
+    sort_unnamed_constructors_first: true
 
     # First test, then cast
-    - test_types_in_equals
+    test_types_in_equals: true
 
     # Hard to debug and bad style
-    - throw_in_finally
+    throw_in_finally: true
 
     # Type annotations make the compiler intelligent, use them
-    - type_annotate_public_apis
-
-    # Don't add types for already typed constructor parameters
-    - type_init_formals
+    type_annotate_public_apis: true
 
     # Remove async/await clutter when not required
-    - unnecessary_await_in_return
-
-    # Remove unnecessary braces
-    - unnecessary_brace_in_string_interps
-
-    # Yes, const everywhere. But not in an already const scope.
-    - unnecessary_const
-
-    # Getter/setters can be added later on in a non API breaking manner
-    - unnecessary_getters_setters
-
-    # Remove the optional `new` keyword
-    - unnecessary_new
+    unnecessary_await_in_return: true
 
     # Don't assign `null` when value is already `null`
-    - unnecessary_null_aware_assignments
+    unnecessary_null_aware_assignments: true
 
-    # Don't assign `null` when value is already `null`
-    - unnecessary_null_in_if_null_operators
-
-    # If a variable doesn't change and is initialized, no need to define it as
-    # nullable (NNDB)
-    - unnecessary_nullable_for_final_variable_declarations
-
-    # Remove overrides which simply call super
-    - unnecessary_overrides
+    # If a variable doesn't change and is initialized, no need to define it as nullable
+    unnecessary_nullable_for_final_variable_declarations: true
 
     # Remove clutter where possible
-    - unnecessary_parenthesis
+    unnecessary_parenthesis: true
 
     # Use raw string only when needed
-    - unnecessary_raw_strings
+    unnecessary_raw_strings: true
 
     # Avoid magic overloads of + operators
-    - unnecessary_statements
-
-    # Remove unnecessary escape characters
-    - unnecessary_string_escapes
-
-    # Especially with NNBD a no-brainer
-    - unnecessary_string_interpolations
-
-    # The variable is clear, remove clutter
-    - unnecessary_this
-
-    # Highlights potential bugs where unrelated types are compared with another
-    - unrelated_type_equality_checks
+    unnecessary_statements: true
 
     # Web only
-    - unsafe_html
+    unsafe_html: true
 
     # The use of intValue.isOdd/isEven to check for evenness.
-    - use_is_even_rather_than_modulo
-
-    # Always use hex syntax Color(0x00000001), never Color(1)
-    - use_full_hex_values_for_flutter_colors
-
-    # Always use generic function type syntax, don't mix styles
-    - use_function_type_syntax_for_parameters
+    use_is_even_rather_than_modulo: true
 
     # Still unsure if `late` is always better than `!` (NNBD)
-    - use_late_for_private_fields_and_variables
-
-    # Use rethrow to preserve the original stacktrace
-    - use_rethrow_when_possible
+    use_late_for_private_fields_and_variables: true
 
     # Use the setter syntax
-    - use_setters_to_change_properties
+    use_setters_to_change_properties: true
 
     # In most cases, using a string buffer is preferred for composing strings
     # due to its improved performance
-    - use_string_buffers
-
-    # Catches invalid regular expressions
-    - valid_regexps
-
-    # Don't assign anything to void
-    - void_checks
+    use_string_buffers: true

--- a/lib/src/egyptian.dart
+++ b/lib/src/egyptian.dart
@@ -45,8 +45,9 @@ class EgyptianFraction implements Comparable<EgyptianFraction> {
   /// Creates an instance of [EgyptianFraction] starting from a [MixedFraction].
   /// The given [fraction] will be converted into an egyptian fraction by
   /// calling the [compute] method.
-  EgyptianFraction.fromMixedFraction({required MixedFraction mixedFraction})
-      : this(fraction: mixedFraction.toFraction());
+  EgyptianFraction.fromMixedFraction({
+    required MixedFraction mixedFraction,
+  }) : this(fraction: mixedFraction.toFraction());
 
   /// Returns a series of [Fraction] representing the egyptian fraction of the
   /// current [fraction] object.

--- a/lib/src/egyptian.dart
+++ b/lib/src/egyptian.dart
@@ -116,6 +116,7 @@ class EgyptianFraction implements Comparable<EgyptianFraction> {
     }
 
     final buffer = StringBuffer()..writeAll(results, ' + ');
+
     return buffer.toString();
   }
 }

--- a/lib/src/extensions/fraction_string.dart
+++ b/lib/src/extensions/fraction_string.dart
@@ -10,10 +10,12 @@ extension FractionString on String {
   bool get isFraction {
     try {
       Fraction.fromString(this);
+
       return true;
     } on FractionException {
       try {
         Fraction.fromGlyph(this);
+
         return true;
       } on FractionException {
         return false;

--- a/lib/src/extensions/mixed_string.dart
+++ b/lib/src/extensions/mixed_string.dart
@@ -11,6 +11,7 @@ extension MixedFractionString on String {
   bool get isMixedFraction {
     try {
       MixedFraction.fromString(this);
+
       return true;
     } on MixedFractionException {
       return false;

--- a/lib/src/mixed.dart
+++ b/lib/src/mixed.dart
@@ -42,7 +42,7 @@ class MixedFraction implements Comparable<MixedFraction> {
   ///
   /// In this case, the object `m` is built as '3 1/3' rather than '1 7/3' since
   /// the latter format is invalid.
-  MixedFraction({
+  factory MixedFraction({
     required int whole,
     required int numerator,
     required int denominator,
@@ -62,15 +62,26 @@ class MixedFraction implements Comparable<MixedFraction> {
     // to transform the fraction and make it proper. The sign whole part may
     // change depending on the sign of the fractional part.
     if (absNumerator > absDenominator) {
-      this.whole = (absNumerator ~/ absDenominator + whole) * sign;
-      this.numerator = absNumerator % absDenominator;
-      this.denominator = absDenominator;
+      return MixedFraction._(
+        whole: (absNumerator ~/ absDenominator + whole) * sign,
+        numerator: absNumerator % absDenominator,
+        denominator: absDenominator,
+      );
     } else {
-      this.whole = whole * sign;
-      this.numerator = absNumerator;
-      this.denominator = absDenominator;
+      return MixedFraction._(
+        whole: whole * sign,
+        numerator: absNumerator,
+        denominator: absDenominator,
+      );
     }
   }
+
+  /// The default constructor.
+  MixedFraction._({
+    required this.whole,
+    required this.numerator,
+    required this.denominator,
+  });
 
   /// Creates an instance of a mixed fraction.
   factory MixedFraction.fromFraction(Fraction fraction) =>

--- a/lib/src/mixed.dart
+++ b/lib/src/mixed.dart
@@ -42,8 +42,11 @@ class MixedFraction implements Comparable<MixedFraction> {
   ///
   /// In this case, the object `m` is built as '3 1/3' rather than '1 7/3' since
   /// the latter format is invalid.
-  MixedFraction(
-      {required int whole, required int numerator, required int denominator}) {
+  MixedFraction({
+    required int whole,
+    required int numerator,
+    required int denominator,
+  }) {
     // Denominator cannot be zero
     if (denominator == 0) {
       throw const MixedFractionException('The denominator cannot be zero');
@@ -159,9 +162,9 @@ class MixedFraction implements Comparable<MixedFraction> {
   int get hashCode {
     var result = 83;
 
-    result = 31 * result + whole.hashCode;
-    result = 31 * result + numerator.hashCode;
-    result = 31 * result + denominator.hashCode;
+    result = result * 31 + whole.hashCode;
+    result = result * 31 + numerator.hashCode;
+    result = result * 31 + denominator.hashCode;
 
     return result;
   }
@@ -253,7 +256,10 @@ class MixedFraction implements Comparable<MixedFraction> {
   /// Changes the sign of this mixed fraction and returns the results in a new
   /// [MixedFraction] instance.
   MixedFraction negate() => MixedFraction(
-      whole: whole * -1, numerator: numerator, denominator: denominator);
+        whole: whole * -1,
+        numerator: numerator,
+        denominator: denominator,
+      );
 
   /// Sum between two mixed fractions.
   MixedFraction operator +(MixedFraction other) =>
@@ -302,8 +308,9 @@ class MixedFraction implements Comparable<MixedFraction> {
         return denominator;
       default:
         throw MixedFractionException(
-            'The index you gave ($index) is not valid: '
-            'it must be either 0, 1 or 2.');
+          'The index you gave ($index) is not valid: '
+          'it must be either 0, 1 or 2.',
+        );
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fraction
 description: A package that helps you dealing with mathematical fractions. Work with fractions, mixed fractions and types conversions.
-version: 3.0.2
+version: 3.1.0
 repository: https://github.com/albertodev01/fraction
 homepage: https://fluttercompletereference.com/
 
@@ -8,5 +8,14 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dev_dependencies:
+  # https://pub.dev/packages/coverage
   coverage: ^1.0.3
-  test: ^1.17.11
+
+  # https://pub.dev/packages/dart_code_metrics
+  dart_code_metrics: ^4.2.1
+
+  # https://pub.dev/packages/lints
+  lints: ^1.0.1
+
+  # https://pub.dev/packages/test
+  test: ^1.17.12

--- a/test/egyptian_test.dart
+++ b/test/egyptian_test.dart
@@ -9,20 +9,25 @@ void main() {
     });
 
     test(
-        'Making sure that the class can correctly be instantiated with the '
-        'mixed fraction constructor', () {
-      final mixed = MixedFraction(whole: 10, numerator: 7, denominator: 2);
-      final egyptian = EgyptianFraction.fromMixedFraction(mixedFraction: mixed);
-      expect(egyptian.fraction, equals(Fraction(27, 2)));
-    });
+      'Making sure that the class can correctly be instantiated with the '
+      'mixed fraction constructor',
+      () {
+        final mixed = MixedFraction(whole: 10, numerator: 7, denominator: 2);
+        final egyptian =
+            EgyptianFraction.fromMixedFraction(mixedFraction: mixed);
+        expect(egyptian.fraction, equals(Fraction(27, 2)));
+      },
+    );
 
-    test('Making sure that the constructor throws in case of invalid fraction',
-        () {
-      expect(
-        () => EgyptianFraction(fraction: Fraction(2, 0)),
-        throwsA(isA<FractionException>()),
-      );
-    });
+    test(
+      'Making sure that the constructor throws in case of invalid fraction',
+      () {
+        expect(
+          () => EgyptianFraction(fraction: Fraction(2, 0)),
+          throwsA(isA<FractionException>()),
+        );
+      },
+    );
 
     test('Making sure that the constructor throws with negative fractions', () {
       expect(
@@ -32,10 +37,14 @@ void main() {
     });
 
     test('Making sure that static methods can be accessed', () {
-      expect(() {
-        EgyptianFraction.clearCache();
-        return EgyptianFraction.cachingEnabled;
-      }(), isTrue);
+      expect(
+        () {
+          EgyptianFraction.clearCache();
+
+          return EgyptianFraction.cachingEnabled;
+        }(),
+        isTrue,
+      );
     });
 
     test('Making sure that caching properly works', () {

--- a/test/extensions/fraction_num_test.dart
+++ b/test/extensions/fraction_num_test.dart
@@ -1,5 +1,5 @@
-import 'package:test/test.dart';
 import 'package:fraction/fraction.dart';
+import 'package:test/test.dart';
 
 void main() {
   group("Testing the extension method on 'num'", () {

--- a/test/extensions/fraction_string_test.dart
+++ b/test/extensions/fraction_string_test.dart
@@ -1,5 +1,5 @@
-import 'package:test/test.dart';
 import 'package:fraction/fraction.dart';
+import 'package:test/test.dart';
 
 void main() {
   group("Testing the extension method on 'String'", () {
@@ -11,21 +11,24 @@ void main() {
       expect('⅘'.toFraction(), equals(Fraction(4, 5)));
     });
 
-    test('Making sure that invalid strings conversions throw and exception',
-        () {
-      expect(() => '1/'.toFraction(), throwsA(isA<FormatException>()));
-      expect(() => '1/0'.toFraction(), throwsA(isA<FractionException>()));
-      expect(() => 'x'.toFraction(), throwsA(isA<FractionException>()));
-      expect(() => '3/-6'.toFraction(), throwsA(isA<FractionException>()));
-      expect(() => ''.toFraction(), throwsA(isA<FractionException>()));
-    });
+    test(
+      'Making sure that invalid strings conversions throw and exception',
+      () {
+        expect(() => '1/'.toFraction(), throwsA(isA<FormatException>()));
+        expect(() => '1/0'.toFraction(), throwsA(isA<FractionException>()));
+        expect(() => 'x'.toFraction(), throwsA(isA<FractionException>()));
+        expect(() => '3/-6'.toFraction(), throwsA(isA<FractionException>()));
+        expect(() => ''.toFraction(), throwsA(isA<FractionException>()));
+      },
+    );
 
     test(
-        'Making sure that the boolean check is safe to be used before converting',
-        () {
-      expect('3/5'.isFraction, isTrue);
-      expect('⅜'.isFraction, isTrue);
-      expect(''.isFraction, isFalse);
-    });
+      'Making sure that the boolean check is safe to be used before converting',
+      () {
+        expect('3/5'.isFraction, isTrue);
+        expect('⅜'.isFraction, isTrue);
+        expect(''.isFraction, isFalse);
+      },
+    );
   });
 }

--- a/test/extensions/mixed_num_test.dart
+++ b/test/extensions/mixed_num_test.dart
@@ -1,30 +1,34 @@
-import 'package:test/test.dart';
 import 'package:fraction/fraction.dart';
+import 'package:test/test.dart';
 
 void main() {
   group("Testing the extension method on 'num'", () {
     test(
-        'Making sure that integers are properly converted into '
-        'mixed fractions', () {
-      final mixedVal = MixedFraction(
-        whole: 0,
-        numerator: 16,
-        denominator: 1,
-      );
+      'Making sure that integers are properly converted into '
+      'mixed fractions',
+      () {
+        final mixedVal = MixedFraction(
+          whole: 0,
+          numerator: 16,
+          denominator: 1,
+        );
 
-      expect(16.toMixedFraction(), equals(mixedVal));
-    });
+        expect(16.toMixedFraction(), equals(mixedVal));
+      },
+    );
 
     test(
-        'Making sure that doubles are properly converted into '
-        'mixed fractions', () {
-      final mixedVal = MixedFraction(
-        whole: 6,
-        numerator: 37,
-        denominator: 50,
-      );
+      'Making sure that doubles are properly converted into '
+      'mixed fractions',
+      () {
+        final mixedVal = MixedFraction(
+          whole: 6,
+          numerator: 37,
+          denominator: 50,
+        );
 
-      expect(6.74.toMixedFraction(), equals(mixedVal));
-    });
+        expect(6.74.toMixedFraction(), equals(mixedVal));
+      },
+    );
   });
 }

--- a/test/extensions/mixed_string_test.dart
+++ b/test/extensions/mixed_string_test.dart
@@ -1,5 +1,5 @@
-import 'package:test/test.dart';
 import 'package:fraction/fraction.dart';
+import 'package:test/test.dart';
 
 void main() {
   group("Testing the extension method on 'String'", () {
@@ -26,38 +26,41 @@ void main() {
       );
     });
 
-    test('Making sure that invalid strings conversions throw and exception',
-        () {
-      expect(
-        () => '1/'.toMixedFraction(),
-        throwsA(isA<MixedFractionException>()),
-      );
-      expect(
-        () => '1/0'.toMixedFraction(),
-        throwsA(isA<MixedFractionException>()),
-      );
-      expect(
-        () => 'x'.toMixedFraction(),
-        throwsA(isA<MixedFractionException>()),
-      );
-      expect(
-        () => '3/-6'.toMixedFraction(),
-        throwsA(isA<MixedFractionException>()),
-      );
-      expect(
-        () => ''.toMixedFraction(),
-        throwsA(isA<MixedFractionException>()),
-      );
-    });
+    test(
+      'Making sure that invalid strings conversions throw and exception',
+      () {
+        expect(
+          () => '1/'.toMixedFraction(),
+          throwsA(isA<MixedFractionException>()),
+        );
+        expect(
+          () => '1/0'.toMixedFraction(),
+          throwsA(isA<MixedFractionException>()),
+        );
+        expect(
+          () => 'x'.toMixedFraction(),
+          throwsA(isA<MixedFractionException>()),
+        );
+        expect(
+          () => '3/-6'.toMixedFraction(),
+          throwsA(isA<MixedFractionException>()),
+        );
+        expect(
+          () => ''.toMixedFraction(),
+          throwsA(isA<MixedFractionException>()),
+        );
+      },
+    );
 
     test(
-        'Making sure that the boolean check is safe to be used before converting',
-        () {
-      expect('1 3/5'.isMixedFraction, isTrue);
-      expect('3 ¾'.isMixedFraction, isTrue);
-      expect('0 -3/5'.isMixedFraction, isTrue);
-      expect(''.isMixedFraction, isFalse);
-      expect('7/4'.isMixedFraction, isFalse);
-    });
+      'Making sure that the boolean check is safe to be used before converting',
+      () {
+        expect('1 3/5'.isMixedFraction, isTrue);
+        expect('3 ¾'.isMixedFraction, isTrue);
+        expect('0 -3/5'.isMixedFraction, isTrue);
+        expect(''.isMixedFraction, isFalse);
+        expect('7/4'.isMixedFraction, isFalse);
+      },
+    );
   });
 }

--- a/test/fraction_test.dart
+++ b/test/fraction_test.dart
@@ -20,14 +20,15 @@ void main() {
     });
 
     test(
-        'Making sure that the sign on the denominator is moved to the numerator',
-        () {
-      final fraction = Fraction(5, -7);
+      'Making sure that the sign on the denominator is moved to the numerator',
+      () {
+        final fraction = Fraction(5, -7);
 
-      expect(fraction.numerator, equals(-5));
-      expect(fraction.denominator, equals(7));
-      expect(fraction.toString(), '-5/7');
-    });
+        expect(fraction.numerator, equals(-5));
+        expect(fraction.denominator, equals(7));
+        expect(fraction.toString(), '-5/7');
+      },
+    );
 
     test('Making sure that whole fractions have the denominator = 1', () {
       final fraction = Fraction(10);
@@ -43,102 +44,118 @@ void main() {
       expect(negativeFraction.toString(), '-8');
     });
 
-    test('Making sure an exception is thrown ONLY when the denominator is zero',
-        () {
-      expect(() => Fraction(1, 0), throwsA(isA<FractionException>()));
-      expect(Fraction(0), equals(Fraction(0)));
-    });
+    test(
+      'Making sure an exception is thrown ONLY when the denominator is zero',
+      () {
+        expect(() => Fraction(1, 0), throwsA(isA<FractionException>()));
+        expect(Fraction(0), equals(Fraction(0)));
+      },
+    );
 
     test(
-        "Making sure that the 'fromString()' constructor handles strings properly",
-        () {
-      // Valid conversions
-      expect(Fraction.fromString('3/5'), equals(Fraction(3, 5)));
-      expect(Fraction.fromString('-3/5'), equals(Fraction(-3, 5)));
-      expect(Fraction.fromString('7'), equals(Fraction(7)));
-      expect(Fraction.fromString('-6'), equals(Fraction(-6)));
+      "Making sure that the 'fromString()' constructor handles strings properly",
+      () {
+        // Valid conversions
+        expect(Fraction.fromString('3/5'), equals(Fraction(3, 5)));
+        expect(Fraction.fromString('-3/5'), equals(Fraction(-3, 5)));
+        expect(Fraction.fromString('7'), equals(Fraction(7)));
+        expect(Fraction.fromString('-6'), equals(Fraction(-6)));
 
-      expect(
-        () => Fraction.fromString('½'),
-        throwsA(isA<FractionException>()),
-      );
+        expect(
+          () => Fraction.fromString('½'),
+          throwsA(isA<FractionException>()),
+        );
 
-      // Invalid conversions
-      expect(
-        () => Fraction.fromString('2/-5'),
-        throwsA(isA<FractionException>()),
-      );
-      expect(
-        () => Fraction.fromString('1/-0'),
-        throwsA(isA<FractionException>()),
-      );
-      expect(
-        () => Fraction.fromString('2/0'),
-        throwsA(isA<FractionException>()),
-      );
-      expect(
-        () => Fraction.fromString('0/0'),
-        throwsA(isA<FractionException>()),
-      );
+        // Invalid conversions
+        expect(
+          () => Fraction.fromString('2/-5'),
+          throwsA(isA<FractionException>()),
+        );
+        expect(
+          () => Fraction.fromString('1/-0'),
+          throwsA(isA<FractionException>()),
+        );
+        expect(
+          () => Fraction.fromString('2/0'),
+          throwsA(isA<FractionException>()),
+        );
+        expect(
+          () => Fraction.fromString('0/0'),
+          throwsA(isA<FractionException>()),
+        );
 
-      // Invalid formats
-      expect(
-        () => Fraction.fromString('2/'),
-        throwsA(isA<FormatException>()),
-      );
-      expect(
-        () => Fraction.fromString('3/a'),
-        throwsA(isA<FormatException>()),
-      );
-    });
-
-    test(
-        "Making sure that the 'fromGlyph()' constructor handles strings properly",
-        () {
-      expect(Fraction.fromGlyph('½'), equals(Fraction(1, 2)));
-      expect(Fraction.fromGlyph('⅓'), equals(Fraction(1, 3)));
-      expect(Fraction.fromGlyph('⅔'), equals(Fraction(2, 3)));
-      expect(Fraction.fromGlyph('¼'), equals(Fraction(1, 4)));
-      expect(Fraction.fromGlyph('¾'), equals(Fraction(3, 4)));
-      expect(Fraction.fromGlyph('⅕'), equals(Fraction(1, 5)));
-      expect(Fraction.fromGlyph('⅖'), equals(Fraction(2, 5)));
-      expect(Fraction.fromGlyph('⅗'), equals(Fraction(3, 5)));
-      expect(Fraction.fromGlyph('⅘'), equals(Fraction(4, 5)));
-      expect(Fraction.fromGlyph('⅙'), equals(Fraction(1, 6)));
-      expect(Fraction.fromGlyph('⅚'), equals(Fraction(5, 6)));
-      expect(Fraction.fromGlyph('⅐'), equals(Fraction(1, 7)));
-      expect(Fraction.fromGlyph('⅛'), equals(Fraction(1, 8)));
-      expect(Fraction.fromGlyph('⅜'), equals(Fraction(3, 8)));
-      expect(Fraction.fromGlyph('⅝'), equals(Fraction(5, 8)));
-      expect(Fraction.fromGlyph('⅞'), equals(Fraction(7, 8)));
-      expect(Fraction.fromGlyph('⅑'), equals(Fraction(1, 9)));
-      expect(Fraction.fromGlyph('⅒'), equals(Fraction(1, 10)));
-    });
+        // Invalid formats
+        expect(
+          () => Fraction.fromString('2/'),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => Fraction.fromString('3/a'),
+          throwsA(isA<FormatException>()),
+        );
+      },
+    );
 
     test(
-        "Making sure that the 'fromDouble()' constructor handles strings properly",
-        () {
-      // Valid conversions
-      expect(Fraction.fromDouble(5.6), equals(Fraction(28, 5)));
-      expect(Fraction.fromDouble(0.0025), equals(Fraction(1, 400)));
-      expect(Fraction.fromDouble(-3.8), equals(Fraction(-19, 5)));
-      expect(Fraction.fromDouble(0), equals(Fraction(0)));
+      "Making sure that the 'fromGlyph()' constructor handles strings properly",
+      () {
+        expect(Fraction.fromGlyph('½'), equals(Fraction(1, 2)));
+        expect(Fraction.fromGlyph('⅓'), equals(Fraction(1, 3)));
+        expect(Fraction.fromGlyph('⅔'), equals(Fraction(2, 3)));
+        expect(Fraction.fromGlyph('¼'), equals(Fraction(1, 4)));
+        expect(Fraction.fromGlyph('¾'), equals(Fraction(3, 4)));
+        expect(Fraction.fromGlyph('⅕'), equals(Fraction(1, 5)));
+        expect(Fraction.fromGlyph('⅖'), equals(Fraction(2, 5)));
+        expect(Fraction.fromGlyph('⅗'), equals(Fraction(3, 5)));
+        expect(Fraction.fromGlyph('⅘'), equals(Fraction(4, 5)));
+        expect(Fraction.fromGlyph('⅙'), equals(Fraction(1, 6)));
+        expect(Fraction.fromGlyph('⅚'), equals(Fraction(5, 6)));
+        expect(Fraction.fromGlyph('⅐'), equals(Fraction(1, 7)));
+        expect(Fraction.fromGlyph('⅛'), equals(Fraction(1, 8)));
+        expect(Fraction.fromGlyph('⅜'), equals(Fraction(3, 8)));
+        expect(Fraction.fromGlyph('⅝'), equals(Fraction(5, 8)));
+        expect(Fraction.fromGlyph('⅞'), equals(Fraction(7, 8)));
+        expect(Fraction.fromGlyph('⅑'), equals(Fraction(1, 9)));
+        expect(Fraction.fromGlyph('⅒'), equals(Fraction(1, 10)));
+      },
+    );
 
-      // Invalid conversions
-      expect(() => Fraction.fromDouble(double.nan),
-          throwsA(isA<FractionException>()));
-      expect(() => Fraction.fromDouble(double.infinity),
-          throwsA(isA<FractionException>()));
-    });
+    test(
+      "Making sure that the 'fromDouble()' constructor handles strings properly",
+      () {
+        // Valid conversions
+        expect(Fraction.fromDouble(5.6), equals(Fraction(28, 5)));
+        expect(Fraction.fromDouble(0.0025), equals(Fraction(1, 400)));
+        expect(Fraction.fromDouble(-3.8), equals(Fraction(-19, 5)));
+        expect(Fraction.fromDouble(0), equals(Fraction(0)));
 
-    test('Making sure that fractions are properly built from mixed fractions',
-        () {
-      final fraction = Fraction.fromMixedFraction(
-          MixedFraction(whole: 3, numerator: 5, denominator: 6));
+        // Invalid conversions
+        expect(
+          () => Fraction.fromDouble(double.nan),
+          throwsA(isA<FractionException>()),
+        );
+        expect(
+          () => Fraction.fromDouble(double.infinity),
+          throwsA(isA<FractionException>()),
+        );
+      },
+    );
 
-      expect(fraction, equals(Fraction(23, 6)));
-      expect(fraction.isNegative, isFalse);
-    });
+    test(
+      'Making sure that fractions are properly built from mixed fractions',
+      () {
+        final fraction = Fraction.fromMixedFraction(
+          MixedFraction(
+            whole: 3,
+            numerator: 5,
+            denominator: 6,
+          ),
+        );
+
+        expect(fraction, equals(Fraction(23, 6)));
+        expect(fraction.isNegative, isFalse);
+      },
+    );
   });
 
   group('Testing objects equality', () {
@@ -151,12 +168,13 @@ void main() {
     });
 
     test(
-        "Making sure that 'compareTo' returns 1, -1 or 0 according with the natural sorting",
-        () {
-      expect(Fraction(2).compareTo(Fraction(8)), equals(-1));
-      expect(Fraction(2).compareTo(Fraction(-4)), equals(1));
-      expect(Fraction(6).compareTo(Fraction(6)), equals(0));
-    });
+      "Making sure that 'compareTo' returns 1, -1 or 0 according with the natural sorting",
+      () {
+        expect(Fraction(2).compareTo(Fraction(8)), equals(-1));
+        expect(Fraction(2).compareTo(Fraction(-4)), equals(1));
+        expect(Fraction(6).compareTo(Fraction(6)), equals(0));
+      },
+    );
   });
 
   group('Testing the API of the Fraction class', () {
@@ -229,13 +247,15 @@ void main() {
     });
 
     test(
-        'Making sure that a non-gliph encodeable fraction throws when trying '
-        'to convert it into a glyph', () {
-      expect(
-        () => Fraction(10, 37).toStringAsGlyph(),
-        throwsA(isA<FractionException>()),
-      );
-    });
+      'Making sure that a non-gliph encodeable fraction throws when trying '
+      'to convert it into a glyph',
+      () {
+        expect(
+          () => Fraction(10, 37).toStringAsGlyph(),
+          throwsA(isA<FractionException>()),
+        );
+      },
+    );
 
     test('Making sure conversions to mixed fractions are correct', () {
       final mixed = Fraction(8, 7).toMixedFraction();
@@ -245,11 +265,13 @@ void main() {
       expect(mixed.denominator, equals(7));
     });
 
-    test('Making sure that the inverse is another fraction with swapped values',
-        () {
-      expect(Fraction(10, 2).inverse(), equals(Fraction(2, 10)));
-      expect(Fraction(-10, 2).inverse(), equals(Fraction(-2, 10)));
-    });
+    test(
+      'Making sure that the inverse is another fraction with swapped values',
+      () {
+        expect(Fraction(10, 2).inverse(), equals(Fraction(2, 10)));
+        expect(Fraction(-10, 2).inverse(), equals(Fraction(-2, 10)));
+      },
+    );
 
     test('Making sure that negation changes the sign', () {
       expect(Fraction(-2, 4).negate(), equals(Fraction(2, 4)));
@@ -266,14 +288,16 @@ void main() {
       expect(Fraction(1, 15).isWhole, isFalse);
     });
 
-    test('Making sure that reduction to the lowest terms works as expected',
-        () {
-      final positiveFraction = Fraction(16, 46);
-      expect(positiveFraction.reduce(), equals(Fraction(8, 23)));
+    test(
+      'Making sure that reduction to the lowest terms works as expected',
+      () {
+        final positiveFraction = Fraction(16, 46);
+        expect(positiveFraction.reduce(), equals(Fraction(8, 23)));
 
-      final negativeFraction = Fraction(-9, 3);
-      expect(negativeFraction.reduce(), equals(Fraction(-3)));
-    });
+        final negativeFraction = Fraction(-9, 3);
+        expect(negativeFraction.reduce(), equals(Fraction(-3)));
+      },
+    );
   });
 
   group('Testing operators overloads', () {
@@ -297,13 +321,14 @@ void main() {
     });
 
     test(
-        'Making sure that the index operator returns value only when called with 0 and 1',
-        () {
-      final fraction = Fraction(9, 20);
+      'Making sure that the index operator returns value only when called with 0 and 1',
+      () {
+        final fraction = Fraction(9, 20);
 
-      expect(fraction[0], equals(9));
-      expect(fraction[1], equals(20));
-      expect(() => fraction[2], throwsA(isA<FractionException>()));
-    });
+        expect(fraction[0], equals(9));
+        expect(fraction[1], equals(20));
+        expect(() => fraction[2], throwsA(isA<FractionException>()));
+      },
+    );
   });
 }

--- a/test/mixed_test.dart
+++ b/test/mixed_test.dart
@@ -24,63 +24,94 @@ void main() {
       expect(fraction.toString(), equals('1/2'));
     });
 
-    test('Making sure that an exception is thrown when the denominator is zero',
-        () {
-      expect(
-        () => MixedFraction(whole: 1, numerator: 5, denominator: 0),
-        throwsA(isA<MixedFractionException>()),
-      );
-    });
+    test(
+      'Making sure that an exception is thrown when the denominator is zero',
+      () {
+        expect(
+          () => MixedFraction(whole: 1, numerator: 5, denominator: 0),
+          throwsA(isA<MixedFractionException>()),
+        );
+      },
+    );
 
     test(
-        "Making sure that when numerator > denominator, the fraction is 'normalized' "
-        'so that the numerator <= denominator relation becomes true', () {
-      final fraction1 = MixedFraction(whole: 1, numerator: 5, denominator: 3);
+      "Making sure that when numerator > denominator, the fraction is 'normalized' "
+      'so that the numerator <= denominator relation becomes true',
+      () {
+        final fraction1 = MixedFraction(
+          whole: 1,
+          numerator: 5,
+          denominator: 3,
+        );
 
-      expect(fraction1.whole, equals(2));
-      expect(fraction1.numerator, equals(2));
-      expect(fraction1.denominator, equals(3));
-      expect(fraction1.toString(), equals('2 2/3'));
+        expect(fraction1.whole, equals(2));
+        expect(fraction1.numerator, equals(2));
+        expect(fraction1.denominator, equals(3));
+        expect(fraction1.toString(), equals('2 2/3'));
 
-      final fraction2 = MixedFraction(whole: 3, numerator: 18, denominator: -7);
+        final fraction2 = MixedFraction(
+          whole: 3,
+          numerator: 18,
+          denominator: -7,
+        );
 
-      expect(fraction2.whole, equals(-5));
-      expect(fraction2.numerator, equals(4));
-      expect(fraction2.denominator, equals(7));
-      expect(fraction2.toString(), equals('-5 4/7'));
+        expect(fraction2.whole, equals(-5));
+        expect(fraction2.numerator, equals(4));
+        expect(fraction2.denominator, equals(7));
+        expect(fraction2.toString(), equals('-5 4/7'));
 
-      final fraction3 = MixedFraction(whole: 2, numerator: -6, denominator: 5);
+        final fraction3 = MixedFraction(
+          whole: 2,
+          numerator: -6,
+          denominator: 5,
+        );
 
-      expect(fraction3.whole, equals(-3));
-      expect(fraction3.numerator, equals(1));
-      expect(fraction3.denominator, equals(5));
-      expect(fraction3.toString(), equals('-3 1/5'));
+        expect(fraction3.whole, equals(-3));
+        expect(fraction3.numerator, equals(1));
+        expect(fraction3.denominator, equals(5));
+        expect(fraction3.toString(), equals('-3 1/5'));
 
-      final fraction4 = MixedFraction(whole: -5, numerator: -1, denominator: 3);
+        final fraction4 = MixedFraction(
+          whole: -5,
+          numerator: -1,
+          denominator: 3,
+        );
 
-      expect(fraction4.whole, equals(5));
-      expect(fraction4.numerator, equals(1));
-      expect(fraction4.denominator, equals(3));
-      expect(fraction4.toString(), equals('5 1/3'));
-    });
+        expect(fraction4.whole, equals(5));
+        expect(fraction4.numerator, equals(1));
+        expect(fraction4.denominator, equals(3));
+        expect(fraction4.toString(), equals('5 1/3'));
+      },
+    );
 
     test('Making sure that negative signs are properly handled', () {
-      final fraction1 = MixedFraction(whole: -1, numerator: -4, denominator: 9);
+      final fraction1 = MixedFraction(
+        whole: -1,
+        numerator: -4,
+        denominator: 9,
+      );
 
       expect(fraction1.whole, equals(1));
       expect(fraction1.numerator, equals(4));
       expect(fraction1.denominator, equals(9));
       expect(fraction1.toString(), equals('1 4/9'));
 
-      final fraction2 =
-          MixedFraction(whole: -2, numerator: -4, denominator: -11);
+      final fraction2 = MixedFraction(
+        whole: -2,
+        numerator: -4,
+        denominator: -11,
+      );
 
       expect(fraction2.whole, equals(-2));
       expect(fraction2.numerator, equals(4));
       expect(fraction2.denominator, equals(11));
       expect(fraction2.toString(), equals('-2 4/11'));
 
-      final fraction3 = MixedFraction(whole: 6, numerator: 2, denominator: -7);
+      final fraction3 = MixedFraction(
+        whole: 6,
+        numerator: 2,
+        denominator: -7,
+      );
 
       expect(fraction3.whole, equals(-6));
       expect(fraction3.numerator, equals(2));
@@ -89,61 +120,78 @@ void main() {
     });
 
     test(
-        'Making sure that mixed fractions are properly constructed from fractions',
-        () {
-      final fraction = MixedFraction.fromFraction(Fraction(19, 3));
+      'Making sure that mixed fractions are properly constructed from fractions',
+      () {
+        final fraction = MixedFraction.fromFraction(
+          Fraction(19, 3),
+        );
 
-      expect(fraction.whole, equals(6));
-      expect(fraction.numerator, equals(1));
-      expect(fraction.denominator, equals(3));
-    });
+        expect(fraction.whole, equals(6));
+        expect(fraction.numerator, equals(1));
+        expect(fraction.denominator, equals(3));
+      },
+    );
 
     test(
-        'Making sure that mixed fractions are properly constructed from strings',
-        () {
-      // Valid conversions
-      expect(
-        MixedFraction.fromString('-3 6/11'),
-        equals(MixedFraction(whole: -3, numerator: 6, denominator: 11)),
-      );
+      'Making sure that mixed fractions are properly constructed from strings',
+      () {
+        // Valid conversions
+        expect(
+          MixedFraction.fromString('-3 6/11'),
+          equals(MixedFraction(whole: -3, numerator: 6, denominator: 11)),
+        );
 
-      expect(
-        MixedFraction.fromString('1 5/3'),
-        equals(MixedFraction(whole: 2, numerator: 2, denominator: 3)),
-      );
+        expect(
+          MixedFraction.fromString('1 5/3'),
+          equals(MixedFraction(whole: 2, numerator: 2, denominator: 3)),
+        );
 
-      expect(
-        MixedFraction.fromString('3 ⅕'),
-        equals(MixedFraction(whole: 3, numerator: 1, denominator: 5)),
-      );
+        expect(
+          MixedFraction.fromString('3 ⅕'),
+          equals(MixedFraction(whole: 3, numerator: 1, denominator: 5)),
+        );
 
-      // Invalid conversions
-      expect(
-        () => MixedFraction.fromString('1/2'),
-        throwsA(isA<MixedFractionException>()),
-      );
-      expect(
-        () => MixedFraction.fromString('1  3/2'),
-        throwsA(isA<MixedFractionException>()),
-      );
-      expect(
-        () => MixedFraction.fromString('2  1/1'),
-        throwsA(isA<MixedFractionException>()),
-      );
-      expect(
-        () => MixedFraction.fromString('2 c/0'),
-        throwsA(isA<FractionException>()),
-      );
-    });
+        // Invalid conversions
+        expect(
+          () => MixedFraction.fromString('1/2'),
+          throwsA(isA<MixedFractionException>()),
+        );
+        expect(
+          () => MixedFraction.fromString('1  3/2'),
+          throwsA(isA<MixedFractionException>()),
+        );
+        expect(
+          () => MixedFraction.fromString('2  1/1'),
+          throwsA(isA<MixedFractionException>()),
+        );
+        expect(
+          () => MixedFraction.fromString('2 c/0'),
+          throwsA(isA<FractionException>()),
+        );
+      },
+    );
   });
 
   group('Testing objects equality', () {
     test('Making sure that fractions comparison is made via cross product', () {
-      final mixed1 = MixedFraction(whole: 1, numerator: 4, denominator: 7);
-      final mixed2 = MixedFraction(whole: 1, numerator: 8, denominator: 14);
+      final mixed1 = MixedFraction(
+        whole: 1,
+        numerator: 4,
+        denominator: 7,
+      );
+      final mixed2 = MixedFraction(
+        whole: 1,
+        numerator: 8,
+        denominator: 14,
+      );
 
       expect(
-        mixed1 == MixedFraction(whole: 1, numerator: 4, denominator: 7),
+        mixed1 ==
+            MixedFraction(
+              whole: 1,
+              numerator: 4,
+              denominator: 7,
+            ),
         isTrue,
       );
       expect(mixed1 == mixed2, isTrue);
@@ -151,37 +199,53 @@ void main() {
       expect(mixed1.hashCode != mixed2.hashCode, isTrue);
       expect(
         mixed1.hashCode ==
-            MixedFraction(whole: 1, numerator: 4, denominator: 7).hashCode,
+            MixedFraction(
+              whole: 1,
+              numerator: 4,
+              denominator: 7,
+            ).hashCode,
         isTrue,
       );
     });
 
     test(
-        "Making sure that 'compareTo' returns 1, -1 or 0 according with the natural sorting",
-        () {
-      final mixed1 = MixedFraction(whole: 0, numerator: -2, denominator: 4);
-      final mixed2 = MixedFraction(whole: 1, numerator: 6, denominator: 4);
+      "Making sure that 'compareTo' returns 1, -1 or 0 according with the natural sorting",
+      () {
+        final mixed1 = MixedFraction(whole: 0, numerator: -2, denominator: 4);
+        final mixed2 = MixedFraction(whole: 1, numerator: 6, denominator: 4);
 
-      expect(mixed1.compareTo(mixed2), equals(-1));
-      expect(mixed2.compareTo(mixed1), equals(1));
-      expect(mixed1.compareTo(mixed1), equals(0));
-    });
+        expect(mixed1.compareTo(mixed2), equals(-1));
+        expect(mixed2.compareTo(mixed1), equals(1));
+        expect(mixed1.compareTo(mixed1), equals(0));
+      },
+    );
   });
 
   group('Testing the API of the MixedFraction class', () {
     test(
-        'Making sure conversions that, if the fraction is gliph-encodeable, '
-        "the 'toStringAsGliph()' method works", () {
-      final frac1 = MixedFraction(whole: -2, numerator: 1, denominator: 2)
-          .toStringAsGlyph();
-      final frac2 = MixedFraction(whole: 0, numerator: 1, denominator: 2)
-          .toStringAsGlyph();
-      final frac3 = Fraction(12, 15).toMixedFraction();
+      'Making sure conversions that, if the fraction is gliph-encodeable, '
+      "the 'toStringAsGliph()' method works",
+      () {
+        final frac1 = MixedFraction(
+          whole: -2,
+          numerator: 1,
+          denominator: 2,
+        ).toStringAsGlyph();
+        final frac2 = MixedFraction(
+          whole: 0,
+          numerator: 1,
+          denominator: 2,
+        ).toStringAsGlyph();
+        final frac3 = Fraction(12, 15).toMixedFraction();
 
-      expect(frac1, equals('-2 ½'));
-      expect(frac2, equals('½'));
-      expect(() => frac3.toStringAsGlyph(), throwsA(isA<FractionException>()));
-    });
+        expect(frac1, equals('-2 ½'));
+        expect(frac2, equals('½'));
+        expect(
+          () => frac3.toStringAsGlyph(),
+          throwsA(isA<FractionException>()),
+        );
+      },
+    );
 
     test('Making sure conversions to egyptian fractions are correct', () {
       final mixedFraction1 = Fraction(2, 3).toMixedFraction();
@@ -246,8 +310,11 @@ void main() {
     });
 
     test('Making sure reduction on the fractional part properly works', () {
-      final fraction1 =
-          MixedFraction(whole: 1, numerator: 3, denominator: 6).reduce();
+      final fraction1 = MixedFraction(
+        whole: 1,
+        numerator: 3,
+        denominator: 6,
+      ).reduce();
 
       expect(fraction1.whole, equals(1));
       expect(fraction1.numerator, equals(1));
@@ -301,12 +368,14 @@ void main() {
     });
 
     test(
-        'Making sure that the index operator returns value only when called '
-        'with 0, 1 and 2', () {
-      expect(mixed1[0], equals(1));
-      expect(mixed1[1], equals(7));
-      expect(mixed1[2], equals(10));
-      expect(() => mixed1[3], throwsA(isA<MixedFractionException>()));
-    });
+      'Making sure that the index operator returns value only when called '
+      'with 0, 1 and 2',
+      () {
+        expect(mixed1[0], equals(1));
+        expect(mixed1[1], equals(7));
+        expect(mixed1[2], equals(10));
+        expect(() => mixed1[3], throwsA(isA<MixedFractionException>()));
+      },
+    );
   });
 }

--- a/test/utils/exceptions_test.dart
+++ b/test/utils/exceptions_test.dart
@@ -3,37 +3,45 @@ import 'package:test/test.dart';
 
 void main() {
   group('Testing the correctness of exception objects', () {
-    test('Making sure that equality comparison works for exception objects',
-        () {
-      const fractionException = FractionException('Message');
-      const mixedException = MixedFractionException('Message');
+    test(
+      'Making sure that equality comparison works for exception objects',
+      () {
+        const fractionException = FractionException('Message');
+        const mixedException = MixedFractionException('Message');
 
-      expect(fractionException, equals(const FractionException('Message')));
-      expect(mixedException, equals(const MixedFractionException('Message')));
-      expect(fractionException, isNot(mixedException));
-      expect(mixedException, isNot(fractionException));
+        expect(fractionException, equals(const FractionException('Message')));
+        expect(mixedException, equals(const MixedFractionException('Message')));
+        expect(fractionException, isNot(mixedException));
+        expect(mixedException, isNot(fractionException));
 
-      expect(fractionException == const FractionException('Message'), isTrue);
-      expect(mixedException == const MixedFractionException('Message'), isTrue);
+        expect(
+          fractionException == const FractionException('Message'),
+          isTrue,
+        );
+        expect(
+          mixedException == const MixedFractionException('Message'),
+          isTrue,
+        );
 
-      expect(
-        fractionException == const FractionException('Other msg'),
-        isFalse,
-      );
-      expect(
-        mixedException == const MixedFractionException('Other msg'),
-        isFalse,
-      );
+        expect(
+          fractionException == const FractionException('Other msg'),
+          isFalse,
+        );
+        expect(
+          mixedException == const MixedFractionException('Other msg'),
+          isFalse,
+        );
 
-      expect(
-        fractionException.hashCode,
-        equals(const FractionException('Message').hashCode),
-      );
-      expect(
-        mixedException.hashCode,
-        equals(const MixedFractionException('Message').hashCode),
-      );
-    });
+        expect(
+          fractionException.hashCode,
+          equals(const FractionException('Message').hashCode),
+        );
+        expect(
+          mixedException.hashCode,
+          equals(const MixedFractionException('Message').hashCode),
+        );
+      },
+    );
 
     test("Making sure that 'FractionException' prints the correct message", () {
       const exception = FractionException('Exception message');
@@ -41,11 +49,19 @@ void main() {
       expect('$exception', equals('FractionException: Exception message'));
     });
 
-    test("Making sure that 'MixedFractionException' prints the correct message",
-        () {
-      const exception = MixedFractionException('Exception message');
-      expect(exception.message, 'Exception message');
-      expect('$exception', equals('MixedFractionException: Exception message'));
-    });
+    test(
+      "Making sure that 'MixedFractionException' prints the correct message",
+      () {
+        const exception = MixedFractionException('Exception message');
+        expect(
+          exception.message,
+          'Exception message',
+        );
+        expect(
+          '$exception',
+          equals('MixedFractionException: Exception message'),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Why?

With the new Dart 2.14 release, there is a new recommended set of lints to apply. The package also needs stricter lint rules

## What?

I have added the Dart's official [`lints`](https://pub.dev/packages/lints) package and the [`dart_code_metrics`](https://pub.dev/packages/dart_code_metrics) one as well

## Types of Changes

 - New feature (non-breaking change which adds functionality)

## Notes

No new features added

## Checklist

- [x] I have provided a description of the proposed changes.
- [x] I added unit tests for all relevant code.
- [x] I added golden tests for all UI changes.
- [x] I added documentation for all relevant code.