### PR TITLE
Adds whole numbers support for mixedfraction.toString()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.4
+ - Updated Dart SDK constraints to `^3.6.0` 
+ - Dependencies update
+ - Mixed fractions now return just the whole part when the numerator is 0
+
 ## 5.0.3
  - Updated Dart SDK constraints to `^3.4.0` 
  - Dependencies update

--- a/lib/src/types/mixed.dart
+++ b/lib/src/types/mixed.dart
@@ -245,6 +245,10 @@ base class MixedFraction extends Rational {
       return '$numerator/$denominator';
     }
 
+    if (numerator == 0) {
+      return '$whole';
+    }
+
     return '$whole $numerator/$denominator';
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: fraction
 description: A package that helps you work with fractions and mixed fractions.
-version: 5.0.3
+version: 5.0.4
 repository: https://github.com/albertodev01/fraction
 homepage: https://pub.dev/packages/fraction
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.6.0
 
 dev_dependencies:
-  test: ^1.25.8
+  test: ^1.25.12

--- a/test/types/mixed_test.dart
+++ b/test/types/mixed_test.dart
@@ -32,6 +32,20 @@ void main() {
       expect(fraction.toString(), equals('1/2'));
     });
 
+    test('Making sure that whole, numerator and denominator are correct', () {
+      final fraction = MixedFraction(
+        whole: 2,
+        numerator: 0,
+        denominator: 1,
+      );
+
+      expect(fraction.whole, equals(2));
+      expect(fraction.numerator, equals(0));
+      expect(fraction.denominator, equals(1));
+      expect(fraction.isNegative, isFalse);
+      expect(fraction.toString(), equals('2'));
+    });
+
     test(
       'Making sure that an exception is thrown when the denominator is zero',
       () {


### PR DESCRIPTION
## Why?

Adds support for representing whole numbers as string when used with MixedFraction.

## What?

A check whether the numerator equals 0 and if so simply returns the whole part of the mixed fraction

## Types of Changes

<!-- Uncomment the type(s) that matches the changes in this Pull Request. -->

- Bug fix (non-breaking change which fixes an issue)
<!-- - New feature (non-breaking change which adds functionality) -->
<!-- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!-- - Documentation change (change to update documentation) -->

## Notes

<!--- If appropriate, provide some additional notes relevant to the PR. --->

## Checklist

- [x] I have provided a description of the proposed changes.
- [x] I added unit tests for all relevant code.
- [x] I made sure that code coverage is at 100%.
- [x] I added documentation for all relevant code.